### PR TITLE
Use bash for submission

### DIFF
--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -247,7 +247,7 @@ class SubmissionConductor(object):
                 # Capture submission command return value so that we can
                 # intercept and report basic submission failures; #167
                 try:
-                    subprocess.check_call(submission_command, shell=True)
+                    subprocess.check_call(submission_command, shell=True, executable="/bin/bash")
                 except subprocess.CalledProcessError:
                     fails = "" if self.collate \
                         else [s.sample_name for s in self._samples]


### PR DESCRIPTION
Awhile ago I ran into an issue using looper in an environment that wasn't running on bash.

This solved the problem. I'm not sure this is what we should do, but wanted to document that if the shell isn't bash, then the config files can't use bash constructs... so we may want to think of a systematic way to handle this.