### PR TITLE
implement write_custom_template plugin

### DIFF
--- a/docs/pre-submission-hooks.md
+++ b/docs/pre-submission-hooks.md
@@ -123,6 +123,20 @@ Populates an independent jinja template with values from all the available loope
 - `pipeline.var_templates.custom_template` (required): a jinja template to be populated for each job.
 - `pipeline.var_templates.custom_template_output` (optional): path to which the populated template file will be saved. If not provided, the populated fill will be saved in `{looper.output_dir}/submission/{sample.sample_name}_config.yaml
 
+**Example usage:**
+
+```yaml
+pipeline_type: sample
+var_templates:
+  custom_template: custom_template.jinja
+  custom_template_output: "{looper.output_dir}/submission/{sample.sample_name}_custom_config.yaml"
+pre_submit:
+  python_functions:
+    - looper.write_custom_template
+command_template: >
+  {pipeline.var_templates.main} ...
+```
+
 
 ## Writing your own pre-submission hooks
 

--- a/docs/pre-submission-hooks.md
+++ b/docs/pre-submission-hooks.md
@@ -115,6 +115,15 @@ command_template: >
   {pipeline.var_templates.main} ...
 ```
 
+### Included plugin: `looper.write_custom_template`
+
+Populates an independent jinja template with values from all the available looper namespaces.
+
+**Parameters:**
+- `pipeline.var_templates.custom_template` (required): a jinja template to be populated for each job.
+- `pipeline.var_templates.custom_template_output` (optional): path to which the populated template file will be saved. If not provided, the populated fill will be saved in `{looper.output_dir}/submission/{sample.sample_name}_config.yaml
+
+
 ## Writing your own pre-submission hooks
 
 Pre-submission tasks can be written as a Python function or a shell commands. We will explain each type below:

--- a/looper/__init__.py
+++ b/looper/__init__.py
@@ -26,6 +26,7 @@ from .conductor import (
     write_sample_yaml_cwl,
     write_sample_yaml_prj,
     write_submission_yaml,
+    write_custom_template,
 )
 from .const import *
 from .parser_types import *

--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -136,11 +136,11 @@ def write_custom_template(namespaces):
     err_msg = (
         "Custom template plugin requires a template in var_templates.custom_template"
     )
-    if not "var_templates" in namespaces["pipeline"].keys():
+    if "var_templates" not in namespaces["pipeline"].keys():
         _LOGGER.error(err_msg)
         return None
 
-    if not "custom_template" in namespaces["pipeline"]["var_templates"].keys():
+    if "custom_template" not in namespaces["pipeline"]["var_templates"].keys():
         _LOGGER.error(err_msg)
         return None
 

--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -133,7 +133,9 @@ def write_custom_template(namespaces):
         t = jinja2.Template(x)
         return t
 
-    err_msg = "Custom template plugin requires a template in var_templates.custom_template"
+    err_msg = (
+        "Custom template plugin requires a template in var_templates.custom_template"
+    )
     if not "var_templates" in namespaces["pipeline"].keys():
         _LOGGER.error(err_msg)
         return None
@@ -141,7 +143,7 @@ def write_custom_template(namespaces):
     if not "custom_template" in namespaces["pipeline"]["var_templates"].keys():
         _LOGGER.error(err_msg)
         return None
-        
+
     import jinja2
 
     tpl = load_template(namespaces["pipeline"])


### PR DESCRIPTION
This PR introduces a new built-in pre-submit plugin that allows users to populate a custom jinja-template  using all available looper namespace variables.