### PR TITLE
Add required argument to LooperCounter.show() call in Cleaner

### DIFF
--- a/looper/looper.py
+++ b/looper/looper.py
@@ -236,7 +236,7 @@ class Cleaner(Executor):
         :param argparse.Namespace args: command-line options and arguments
         :param bool preview_flag: whether to halt before actually removing files
         """
-        self.counter.show()
+        self.counter.show(name=self.prj.name, type="project")
         for sample in self.prj.samples:
             _LOGGER.info(self.counter.show(sample.sample_name))
             sample_output_folder = sample_folder(self.prj, sample)
@@ -934,6 +934,8 @@ class LooperCounter(object):
         and as a side-effect of the call, the running count is incremented.
 
         :param str name: name of the sample
+        :param str type: the name of the level of entity being displayed,
+            either project or sample
         :param str pipeline_name: name of the pipeline
         :return str: message suitable for logging a status update
         """

--- a/looper/project.py
+++ b/looper/project.py
@@ -228,9 +228,9 @@ class Project(peppyProject):
         :param str default: if key not specified, a default to use
         :return str: path to the folder
         """
-        return os.path.join(
-            getattr(self, OUTDIR_KEY), getattr(self[EXTRA_KEY], key) or default
-        )
+        parent = getattr(self, OUTDIR_KEY)
+        child = getattr(self[EXTRA_KEY], key, default)
+        return os.path.join(parent, child)
 
     def make_project_dirs(self):
         """

--- a/looper/utils.py
+++ b/looper/utils.py
@@ -110,10 +110,9 @@ def grab_project_data(prj):
         return {}
 
     try:
-        data = prj[CONFIG_KEY]
+        return prj[CONFIG_KEY]
     except KeyError:
         _LOGGER.debug("Project lacks section '%s', skipping", CONFIG_KEY)
-    return data
 
 
 def sample_folder(prj, sample):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,9 +104,7 @@ def mod_yaml_data(path):
 
 @pytest.fixture
 def example_pep_piface_path():
-    return os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
-    )
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
 @pytest.fixture

--- a/tests/smoketests/test_other.py
+++ b/tests/smoketests/test_other.py
@@ -2,7 +2,7 @@ import pytest
 from peppy import Project
 
 from looper.const import FLAGS
-from tests.smoketests.conftest import *
+from tests.conftest import *
 
 
 def _make_flags(cfg, type, count):

--- a/tests/smoketests/test_run.py
+++ b/tests/smoketests/test_run.py
@@ -4,7 +4,7 @@ from yaml import dump
 
 from looper.const import *
 from looper.project import Project
-from tests.smoketests.conftest import *
+from tests.conftest import *
 
 CMD_STRS = ["string", " --string", " --sjhsjd 212", "7867#$@#$cc@@"]
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,37 @@
+"""Tests for looper's cleaning functionality"""
+
+import argparse
+import pytest
+from looper.looper import Cleaner
+from looper import Project
+
+
+def build_namespace(**kwargs):
+    """Create an argparse namespace with given key-value pairs."""
+    ns = argparse.Namespace()
+    for opt, arg in kwargs.items():
+        setattr(ns, opt, arg)
+    return ns
+
+
+DRYRUN_OR_NOT_PREVIEW = [
+    pytest.param(args, preview, id=param_name)
+    for args, preview, param_name in [
+        (build_namespace(dry_run=False), False, "not_preview__only"),
+        (build_namespace(dry_run=True), False, "dry_run__only"),
+        (build_namespace(dry_run=True), True, "dry_run__and__not_preview"),
+    ]
+]
+
+
+@pytest.mark.parametrize(["args", "preview"], DRYRUN_OR_NOT_PREVIEW)
+def test_cleaner_does_not_crash(args, preview, prep_temp_pep):
+    prj = Project(prep_temp_pep)
+    prj.samples = []
+    clean = Cleaner(prj)
+    try:
+        retcode = clean(args=args, preview_flag=preview)
+    except Exception as e:
+        pytest.fail(f"Cleaning call hit error: {e}")
+    else:
+        assert retcode == 0


### PR DESCRIPTION
- Fix #358 
- Add test to show fail/pass transition as a result of fix for #358 
- Reorganize tests to partition smoketests (more time-consuming / using subprocess) from quicker units
- Minor docs and syntax tweaks