### PR TITLE
Replaced SAMPLE_NAME_ATTR with sample_table_index where seen

### DIFF
--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -13,6 +13,7 @@ from attmap import AttMap
 from eido import read_schema, validate_inputs
 from eido.const import INPUT_FILE_SIZE_KEY, MISSING_KEY
 from jinja2.exceptions import UndefinedError
+
 from peppy.const import CONFIG_KEY, SAMPLE_NAME_ATTR, SAMPLE_YAML_EXT
 from peppy.exceptions import RemoteYAMLError
 from pipestat import PipestatError
@@ -464,7 +465,7 @@ class SubmissionConductor(object):
             if not self.collate:
                 for s in self._pool:
                     schemas = self.prj.get_schemas(
-                        self.prj.get_sample_piface(s[SAMPLE_NAME_ATTR]),
+                        self.prj.get_sample_piface(s[self.prj.sample_table_index]),
                         OUTPUT_SCHEMA_KEY,
                     )
 

--- a/looper/html_reports_pipestat.py
+++ b/looper/html_reports_pipestat.py
@@ -542,7 +542,7 @@ class HTMLReportBuilder(object):
             template=self.create_status_html(status_tab, navbar, footer),
         )
         # Complete and close HTML file
-        columns = [SAMPLE_NAME_ATTR] + list(sample_stat_results.keys())
+        columns = [self.prj.sample_table_index] + list(sample_stat_results.keys())
         template_vars = dict(
             navbar=navbar,
             stats_file_path=stats_file_path,

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -446,7 +446,9 @@ class Runner(Executor):
         for sample in self.prj.samples[:upper_sample_bound]:
             pl_fails = []
             skip_reasons = []
-            sample_pifaces = self.prj.get_sample_piface(sample[SAMPLE_NAME_ATTR])
+            sample_pifaces = self.prj.get_sample_piface(
+                sample[self.prj.sample_table_index]
+            )
             if not sample_pifaces:
                 skip_reasons.append("No pipeline interfaces defined")
 
@@ -469,7 +471,7 @@ class Runner(Executor):
                         f"sample validation against {schema_file}"
                     )
 
-            processed_samples.add(sample[SAMPLE_NAME_ATTR])
+            processed_samples.add(sample[self.prj.sample_table_index])
 
             for sample_piface in sample_pifaces:
                 _LOGGER.info(
@@ -646,7 +648,7 @@ def _create_stats_summary(project, pipeline_name, project_level, counter):
         for sample in project.samples:
             sn = sample.sample_name
             _LOGGER.info(counter.show(sn, pipeline_name))
-            reported_stats = {SAMPLE_NAME_ATTR: sn}
+            reported_stats = {project.sample_table_index: sn}
             results = fetch_pipeline_results(
                 project=project,
                 pipeline_name=pipeline_name,

--- a/looper/project.py
+++ b/looper/project.py
@@ -14,7 +14,7 @@ from divvy import ComputingConfiguration
 from eido import PathAttrNotFoundError, read_schema
 from jsonschema import ValidationError
 from pandas.core.common import flatten
-from peppy import CONFIG_KEY, OUTDIR_KEY, SAMPLE_NAME_ATTR
+from peppy import CONFIG_KEY, OUTDIR_KEY
 from peppy import Project as peppyProject
 from peppy.utils import make_abs_via_cfg
 from pipestat import PipestatError, PipestatManager
@@ -570,7 +570,7 @@ class Project(peppyProject):
         # imports in schemas. The output schemas can't have the import section,
         # hence it's safe to select the fist element after read_schema() call.
         for sample in self.samples:
-            sample_piface = self.get_sample_piface(sample[SAMPLE_NAME_ATTR])
+            sample_piface = self.get_sample_piface(sample[self.sample_table_index])
             if sample_piface:
                 paths = self.get_schemas(sample_piface, OUTPUT_SCHEMA_KEY)
                 for path in paths:
@@ -687,7 +687,7 @@ class Project(peppyProject):
                         continue
                     else:
                         samples_by_piface.setdefault(source, set())
-                        samples_by_piface[source].add(sample[SAMPLE_NAME_ATTR])
+                        samples_by_piface[source].add(sample[self.sample_table_index])
         for msg in msgs:
             _LOGGER.warning(msg)
         return samples_by_piface

--- a/looper/utils.py
+++ b/looper/utils.py
@@ -124,7 +124,7 @@ def sample_folder(prj, sample):
         folder path.
     :return str: this Project's root folder for the given Sample
     """
-    return os.path.join(prj.results_folder, sample[SAMPLE_NAME_ATTR])
+    return os.path.join(prj.results_folder, sample[prj.sample_table_index])
 
 
 def get_file_for_project(prj, pipeline_name, appendix=None, directory=None):


### PR DESCRIPTION
Made changes across 5 files. All passed pytests. 

Was unable to update one in `conductor.py` with the function `def _get_yaml_path`:
https://github.com/pepkit/looper/blob/df535be2a0bd7257ee37148cb601d688ec557909/looper/conductor.py#L54-L63 

Correct me if I'm wrong but this `else` sets up for the default YAML location so it would be fine resolving into that namespace 'sample.[SAMPLE_NAME_ATTR]'  where `sample_name` is the default right? Trying to use `Project.sample_table_index` causes key errors when running through pytest that seem unavoidable. 