### PR TITLE
Remove (direct) attmap dependency

### DIFF
--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -792,8 +792,8 @@ def _exec_pre_submit(piface, namespaces):
             )
         _LOGGER.debug("Updating namespaces with:\n{}".format(y))
         for namespace, mapping in y.items():
-            for attr, val in mapping.items():
-                setattr(x[namespace], attr, val)
+            for key, val in mapping.items():
+                x[namespace][key] = val
 
     if PRE_SUBMIT_HOOK_KEY in piface:
         pre_submit = piface[PRE_SUBMIT_HOOK_KEY]

--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -8,8 +8,8 @@ import time
 from copy import copy, deepcopy
 from json import loads
 from subprocess import CalledProcessError, check_output
+from typing import *
 
-from attmap import AttMap
 from eido import read_schema, validate_inputs
 from eido.const import INPUT_FILE_SIZE_KEY, MISSING_KEY
 from jinja2.exceptions import UndefinedError
@@ -19,6 +19,7 @@ from peppy.exceptions import RemoteYAMLError
 from pipestat import PipestatError
 from ubiquerg import expandpath
 from yaml import dump
+from yacman import YAMLConfigManager
 
 from .const import *
 from .exceptions import JobSubmissionException
@@ -559,30 +560,31 @@ class SubmissionConductor(object):
         """Create the name for a job submission."""
         return "{}_{}".format(self.pl_iface.pipeline_name, self._sample_lump_name(pool))
 
-    def _set_looper_namespace(self, pool, size):
+    def _build_looper_namespace(self, pool, size):
         """
         Compile a mapping of looper/submission related settings for use in
         the command templates and in submission script creation
-        in divvy (via adapters). Accessible via: {looper.attrname}
+        in divvy (via adapters).
 
         :param Iterable[peppy.Sample] pool: collection of sample instances
         :param float size: cumulative size of the given pool
-        :return attmap.AttMap: looper/submission related settings
+        :return yacman.YAMLConfigManager: looper/submission related settings
         """
-        settings = AttMap()
-        settings.pep_config = self.prj.config_file
-        settings.results_subdir = self.prj.results_folder
-        settings.submission_subdir = self.prj.submission_folder
-        settings.output_dir = self.prj.output_dir
-        settings.sample_output_folder = os.path.join(
+        settings = YAMLConfigManager()
+        settings["pep_config"] = self.prj.config_file
+        settings[RESULTS_SUBDIR_KEY] = self.prj.results_folder
+        settings[SUBMISSION_SUBDIR_KEY] = self.prj.submission_folder
+        settings[OUTDIR_KEY] = self.prj.output_dir
+        # TODO: explore pulling additional constants from peppy and/or divvy.
+        settings["sample_output_folder"] = os.path.join(
             self.prj.results_folder, self._sample_lump_name(pool)
         )
-        settings.job_name = self._jobname(pool)
-        settings.total_input_size = size
-        settings.log_file = (
-            os.path.join(self.prj.submission_folder, settings.job_name) + ".log"
+        settings[JOB_NAME_KEY] = self._jobname(pool)
+        settings["total_input_size"] = size
+        settings["log_file"] = (
+            os.path.join(self.prj.submission_folder, settings[JOB_NAME_KEY]) + ".log"
         )
-        settings.piface_dir = os.path.dirname(self.pl_iface.pipe_iface_file)
+        settings["piface_dir"] = os.path.dirname(self.pl_iface.pipe_iface_file)
         if hasattr(self.prj, "pipeline_config"):
             # Make sure it's a file (it could be provided as null.)
             pl_config_file = self.prj.pipeline_config
@@ -595,10 +597,12 @@ class SubmissionConductor(object):
                     raise IOError(pl_config_file)
                 _LOGGER.info("Found config file: %s", pl_config_file)
                 # Append arg for config file if found
-                settings.pipeline_config = pl_config_file
+                settings["pipeline_config"] = pl_config_file
         return settings
 
-    def _set_pipestat_namespace(self, sample_name=None):
+    def _set_pipestat_namespace(
+        self, sample_name: Optional[str] = None
+    ) -> YAMLConfigManager:
         """
         Compile a mapping of pipestat-related settings for use in
         the command templates. Accessible via: {pipestat.attrname}
@@ -606,7 +610,7 @@ class SubmissionConductor(object):
         :param str sample_name: name of the sample to get the pipestat
             namespace for. If not provided the pipestat namespace will
             be determined based on the Project
-        :return attmap.AttMap: pipestat namespace
+        :return yacman.YAMLConfigManager: pipestat namespace
         """
         try:
             psms = (
@@ -623,7 +627,7 @@ class SubmissionConductor(object):
                 f"{getattr(e, 'message', repr(e))}"
             )
             # return an empty mapping
-            return AttMap()
+            return YAMLConfigManager()
         else:
             full_namespace = {
                 "schema": psm.schema_path,
@@ -633,7 +637,7 @@ class SubmissionConductor(object):
                 "config": psm.config_path,
             }
             filtered_namespace = {k: v for k, v in full_namespace.items() if v}
-            return AttMap(filtered_namespace)
+            return YAMLConfigManager(filtered_namespace)
 
     def write_script(self, pool, size):
         """
@@ -646,7 +650,7 @@ class SubmissionConductor(object):
         # looper settings determination
         if self.collate:
             pool = [None]
-        looper = self._set_looper_namespace(pool, size)
+        looper = self._build_looper_namespace(pool, size)
         commands = []
         namespaces = dict(
             project=self.prj[CONFIG_KEY],
@@ -705,7 +709,7 @@ class SubmissionConductor(object):
                 self._rendered_ok = True
                 self._num_good_job_submissions += 1
                 self._num_total_job_submissions += 1
-        looper.command = "\n".join(commands)
+        looper["command"] = "\n".join(commands)
         if self.collate:
             _LOGGER.debug("samples namespace:\n{}".format(self.prj.samples))
         else:
@@ -719,7 +723,7 @@ class SubmissionConductor(object):
         _LOGGER.debug("compute namespace:\n{}".format(self.prj.dcc.compute))
         _LOGGER.debug("looper namespace:\n{}".format(looper))
         _LOGGER.debug("pipestat namespace:\n{}".format(pipestat_namespace))
-        subm_base = os.path.join(self.prj.submission_folder, looper.job_name)
+        subm_base = os.path.join(self.prj.submission_folder, looper[JOB_NAME_KEY])
         return self.prj.dcc.write_script(
             output_path=subm_base + ".sub", extra_vars=[{"looper": looper}]
         )

--- a/looper/const.py
+++ b/looper/const.py
@@ -69,6 +69,7 @@ __all__ = [
     "PIPESTAT_CONFIG_ATTR_KEY",
     "PIPESTAT_RESULTS_FILE_ATTR_KEY",
     "LOOPER_GENERIC_PIPELINE",
+    "JOB_NAME_KEY",
 ]
 
 FLAGS = ["completed", "running", "failed", "waiting", "partial"]
@@ -134,6 +135,7 @@ SAMPLE_CWL_YAML_PATH_KEY = "sample_cwl_yaml_path"
 TOGGLE_KEY_SELECTOR = "toggle_key"
 SAMPLE_TOGGLE_ATTR = "toggle"
 OUTKEY = "outputs"
+JOB_NAME_KEY = "job_name"
 VAR_TEMPL_KEY = "var_templates"
 COMPUTE_KEY = "compute"
 COMPUTE_PACKAGE_KEY = "package"

--- a/looper/const.py
+++ b/looper/const.py
@@ -70,6 +70,7 @@ __all__ = [
     "PIPESTAT_RESULTS_FILE_ATTR_KEY",
     "LOOPER_GENERIC_PIPELINE",
     "JOB_NAME_KEY",
+    "PIPELINE_INTERFACE_PIPELINE_NAME_KEY",
 ]
 
 FLAGS = ["completed", "running", "failed", "waiting", "partial"]
@@ -146,6 +147,8 @@ NOT_SUB_MSG = "> Not submitted: {}"
 IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".svg", ".gif")
 # this strongly depends on pypiper's profile.tsv format
 PROFILE_COLNAMES = ["pid", "hash", "cid", "runtime", "mem", "cmd", "lock"]
+
+PIPELINE_INTERFACE_PIPELINE_NAME_KEY = "pipeline_name"
 
 # pipestat configuration keys
 DEFAULT_PIPESTAT_CONFIG_ATTR = "pipestat_config"

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -419,7 +419,6 @@ class Runner(Executor):
         self.counter.total = max_cmds
         failures = defaultdict(list)  # Collect problems by sample.
         processed_samples = set()  # Enforce one-time processing.
-        submission_conductors = {}
         comp_vars = compute_kwargs or {}
 
         # Determine number of samples eligible for processing.
@@ -438,6 +437,7 @@ class Runner(Executor):
                     "Could not read remote schema, skipping config validation."
                 )
 
+        submission_conductors = {}
         for piface in self.prj.pipeline_interfaces:
             conductor = SubmissionConductor(
                 pipeline_interface=piface,

--- a/looper/parser_types.py
+++ b/looper/parser_types.py
@@ -1,10 +1,10 @@
 """ Definitions of the parser argument types """
 
-from attmap import PathExAttMap
+from yacman import YAMLConfigManager
 
 
 def html_range(caravel=False, min_val=0, max_val=10, step=1, value=0):
-    caravel_data = PathExAttMap(
+    caravel_data = YAMLConfigManager(
         {
             "element_type": "range",
             "element_args": {
@@ -38,7 +38,7 @@ def html_checkbox(caravel=False, checked=False):
     :return callable: argument to the type parameter of an
         argparse.ArgumentParser's add_argument method.
     """
-    caravel_data = PathExAttMap({"element_type": "checkbox", "element_args": {}})
+    caravel_data = YAMLConfigManager({"element_type": "checkbox", "element_args": {}})
     if checked:
         caravel_data.add_entries({"element_args": {"checked": True}})
 
@@ -62,7 +62,7 @@ def html_select(choices, caravel=False):
         raise TypeError(
             "Argument to choices parameter must be list, got {}.".format(type(choices))
         )
-    caravel_data = PathExAttMap(
+    caravel_data = YAMLConfigManager(
         {"element_type": "select", "element_args": {"option": choices}}
     )
 

--- a/looper/pipeline_interface.py
+++ b/looper/pipeline_interface.py
@@ -62,7 +62,7 @@ class PipelineInterface(YAMLConfigManager):
 
     @property
     def pipeline_name(self):
-        return self.get("pipeline_name")
+        return self["pipeline_name"]
 
     def render_var_templates(self, namespaces):
         """

--- a/looper/pipeline_interface.py
+++ b/looper/pipeline_interface.py
@@ -7,11 +7,10 @@ from warnings import warn
 
 import jsonschema
 import pandas as pd
-from attmap import PathExAttMap as PXAM
 from eido import read_schema
 from peppy import utils as peputil
 from ubiquerg import expandpath, is_url
-from yacman import load_yaml
+from yacman import load_yaml, YAMLConfigManager
 
 from .const import *
 from .exceptions import InvalidResourceSpecificationException
@@ -24,7 +23,7 @@ _LOGGER = getLogger(__name__)
 
 
 @peputil.copy
-class PipelineInterface(PXAM):
+class PipelineInterface(YAMLConfigManager):
     """
     This class parses, holds, and returns information for a yaml file that
     specifies how to interact with each individual pipeline. This
@@ -61,6 +60,10 @@ class PipelineInterface(PXAM):
             self._expand_paths(["path"])
         self._expand_paths(["compute", "dynamic_variables_script_path"])
 
+    @property
+    def pipeline_name(self):
+        return self.get("pipeline_name")
+
     def render_var_templates(self, namespaces):
         """
         Render path templates under 'var_templates' in this pipeline interface.
@@ -72,12 +75,6 @@ class PipelineInterface(PXAM):
             var_templates.update(self[VAR_TEMPL_KEY])
             for k, v in var_templates.items():
                 var_templates[k] = jinja_render_template_strictly(v, namespaces)
-                # setattr(
-                #     var_templates,
-                #     k,
-                #     jinja_render_template_strictly(v, namespaces),
-                # )
-
             return var_templates
         else:
             _LOGGER.debug(

--- a/looper/pipeline_interface.py
+++ b/looper/pipeline_interface.py
@@ -13,7 +13,10 @@ from ubiquerg import expandpath, is_url
 from yacman import load_yaml, YAMLConfigManager
 
 from .const import *
-from .exceptions import InvalidResourceSpecificationException
+from .exceptions import (
+    InvalidResourceSpecificationException,
+    PipelineInterfaceConfigError,
+)
 from .utils import jinja_render_template_strictly
 
 __author__ = "Michal Stolarczyk"
@@ -47,6 +50,10 @@ class PipelineInterface(YAMLConfigManager):
             self.pipe_iface_file = config
             self.source = config
             config = load_yaml(config)
+        if PIPELINE_INTERFACE_PIPELINE_NAME_KEY not in config:
+            raise PipelineInterfaceConfigError(
+                f"'{PIPELINE_INTERFACE_PIPELINE_NAME_KEY}' is required in pipeline interface config data."
+            )
         self.update(config)
         self._validate(schema_src=PIFACE_SCHEMA_SRC)
         if "path" in self:
@@ -62,7 +69,7 @@ class PipelineInterface(YAMLConfigManager):
 
     @property
     def pipeline_name(self):
-        return self["pipeline_name"]
+        return self[PIPELINE_INTERFACE_PIPELINE_NAME_KEY]
 
     def render_var_templates(self, namespaces):
         """

--- a/looper/processed_project.py
+++ b/looper/processed_project.py
@@ -229,9 +229,9 @@ def get_project_outputs(project, schema):
 
     :param peppy.Project project:
     :param Iterable[dict] schema:
-    :return attmap.PathExAttMap: mapping with populated path-like attributes
+    :return yacman.YAMLConfigManager: mapping with populated path-like attributes
     """
-    from attmap import PathExAttMap
+    from yacman import YAMLConfigManager
 
     # if not any([isinstance(project, Project),
     #             issubclass(type(project), Project)]):
@@ -253,4 +253,4 @@ def get_project_outputs(project, schema):
                     "Caught exception: {}.\n Could not populate {} "
                     "path".format(p, str(e))
                 )
-    return PathExAttMap(res)
+    return YAMLConfigManager(res)

--- a/looper/project.py
+++ b/looper/project.py
@@ -625,11 +625,13 @@ class Project(peppyProject):
         """
         pifaces_by_sample = {}
         for source, sample_names in self._samples_by_interface.items():
-            for sample_name in sample_names:
-                pifaces_by_sample.setdefault(sample_name, [])
-                pifaces_by_sample[sample_name].append(
-                    PipelineInterface(source, pipeline_type="sample")
-                )
+            try:
+                pi = PipelineInterface(source, pipeline_type="sample")
+            except PipelineInterfaceConfigError as e:
+                _LOGGER.debug(f"Skipping pipeline interface creation: {e}")
+            else:
+                for sample_name in sample_names:
+                    pifaces_by_sample.setdefault(sample_name, []).append(pi)
         return pifaces_by_sample
 
     def _omit_from_repr(self, k, cls):
@@ -676,7 +678,11 @@ class Project(peppyProject):
                     source = self._resolve_path_with_cfg(source)
                     try:
                         PipelineInterface(source, pipeline_type="sample")
-                    except (ValidationError, IOError) as e:
+                    except (
+                        ValidationError,
+                        IOError,
+                        PipelineInterfaceConfigError,
+                    ) as e:
                         msg = (
                             "Ignoring invalid pipeline interface source: "
                             "{}. Caught exception: {}".format(

--- a/looper/project.py
+++ b/looper/project.py
@@ -292,7 +292,7 @@ class Project(peppyProject):
 
         :return list[looper.PipelineInterface]: list of pipeline interfaces
         """
-        return [i for s in self._interfaces_by_sample.values() for i in s]
+        return [pi for ifaces in self._interfaces_by_sample.values() for pi in ifaces]
 
     @cached_property
     def pipeline_interface_sources(self):

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -1,4 +1,3 @@
-attmap>=0.12.7
 colorama>=0.3.9
 divvy>=0.5.0
 eido>=0.1.3
@@ -10,3 +9,4 @@ peppy>=0.35.4
 pyyaml>=3.12
 rich>=9.10.0
 ubiquerg>=0.5.2
+yacman>=0.9

--- a/tests/smoketests/test_run.py
+++ b/tests/smoketests/test_run.py
@@ -301,7 +301,7 @@ class LooperRunPreSubmissionHooksTests:
     def test_looper_other_plugins(self, prep_temp_pep, plugin, appendix):
         tp = prep_temp_pep
         for path in {
-            piface["pipe_iface_file"] for piface in Project(tp).pipeline_interfaces
+            piface.pipe_iface_file for piface in Project(tp).pipeline_interfaces
         }:
             with mod_yaml_data(path) as piface_data:
                 piface_data[PRE_SUBMIT_HOOK_KEY][PRE_SUBMIT_PY_FUN_KEY] = [plugin]
@@ -321,7 +321,7 @@ class LooperRunPreSubmissionHooksTests:
     def test_looper_command_templates_hooks(self, prep_temp_pep, cmd):
         tp = prep_temp_pep
         for path in {
-            piface["pipe_iface_file"] for piface in Project(tp).pipeline_interfaces
+            piface.pipe_iface_file for piface in Project(tp).pipeline_interfaces
         }:
             with mod_yaml_data(path) as piface_data:
                 piface_data[PRE_SUBMIT_HOOK_KEY][PRE_SUBMIT_CMD_KEY] = [cmd]


### PR DESCRIPTION
As noted by @Khoroshevskyi we'll still for the moment have indirect/transitive dependency on attmap through some other projects which continue to use it, but this removes looper's _direct_ dependency on `attmap`.

Close #345 

This does a handful of other things like tweaking function names and local variable names for readability, moving a variable declaration closer to where the value (a collection) is then built up, and minimizing number of pipeline interface instances which are built by moving an iteration-independent construction of one out of a for loop, such that it's just done once at the beginning of the loop. But the majority of the changes are directly related to the removal of `attmap` dependency (in favor of `YAMLConfigManager` over `AttMap` or its subtypes).