### PR TITLE
Remove --toggle-key functionality

### DIFF
--- a/looper/__init__.py
+++ b/looper/__init__.py
@@ -390,12 +390,6 @@ def build_parser():
             )
 
             fetch_samples_group.add_argument(
-                "-g",
-                "--toggle-key",
-                metavar="K",
-                help="Sample attribute specifying toggle. Default: toggle",
-            )
-            fetch_samples_group.add_argument(
                 f"--{SAMPLE_SELECTION_ATTRIBUTE_OPTNAME}",
                 default="toggle",
                 metavar="ATTR",

--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -401,14 +401,6 @@ class SubmissionConductor(object):
                     msg += f". Determined status: {', '.join(sample_statuses)}"
                 _LOGGER.info(msg)
 
-        if self.prj.toggle_key in sample and int(sample[self.prj.toggle_key]) == 0:
-            _LOGGER.warning(
-                "> Skipping sample ({}: {})".format(
-                    self.prj.toggle_key, sample[self.prj.toggle_key]
-                )
-            )
-            use_this_sample = False
-
         skip_reasons = []
         validation = {}
         validation.setdefault(INPUT_FILE_SIZE_KEY, 0)
@@ -438,11 +430,8 @@ class SubmissionConductor(object):
         else:
             self._curr_skip_size += float(validation[INPUT_FILE_SIZE_KEY])
             self._curr_skip_pool.append(sample)
-            if self.prj.toggle_key in sample and int(sample[self.prj.toggle_key]) == 0:
-                pass
-            else:
-                self.write_script(self._curr_skip_pool, self._curr_skip_size)
-                self._reset_curr_skips()
+            self.write_script(self._curr_skip_pool, self._curr_skip_size)
+            self._reset_curr_skips()
 
         return skip_reasons
 

--- a/looper/const.py
+++ b/looper/const.py
@@ -43,7 +43,6 @@ __all__ = [
     "IMAGE_EXTS",
     "PROFILE_COLNAMES",
     "SAMPLE_TOGGLE_ATTR",
-    "TOGGLE_KEY_SELECTOR",
     "LOOPER_DOTFILE_NAME",
     "POSITIONAL",
     "EXTRA_PROJECT_CMD_TEMPLATE",
@@ -133,7 +132,6 @@ SAMPLE_YAML_PATH_KEY = "sample_yaml_path"
 SAMPLE_YAML_PRJ_PATH_KEY = "sample_yaml_prj_path"
 SUBMISSION_YAML_PATH_KEY = "submission_yaml_path"
 SAMPLE_CWL_YAML_PATH_KEY = "sample_cwl_yaml_path"
-TOGGLE_KEY_SELECTOR = "toggle_key"
 SAMPLE_TOGGLE_ATTR = "toggle"
 OUTKEY = "outputs"
 JOB_NAME_KEY = "job_name"
@@ -178,7 +176,6 @@ ALL_SUBCMD_KEY = "all"
 DEFAULT_CFG_PATH = os.path.join(os.getcwd(), LOOPER_DOTFILE_NAME)
 CLI_PROJ_ATTRS = [
     OUTDIR_KEY,
-    TOGGLE_KEY_SELECTOR,
     SUBMISSION_SUBDIR_KEY,
     PIPELINE_INTERFACES_KEY,
     RESULTS_SUBDIR_KEY,

--- a/looper/project.py
+++ b/looper/project.py
@@ -735,12 +735,15 @@ def fetch_samples(
     if selector_attribute is None or (not selector_include and not selector_exclude):
         # Default case where user does not use selector_include or selector exclude.
         # Assume that user wants to exclude samples if toggle = 0.
-        if any([hasattr(s, 'toggle') for s in prj.samples]):
+        if any([hasattr(s, "toggle") for s in prj.samples]):
             selector_exclude = [0]
+
             def keep(s):
-                return not hasattr(s, selector_attribute) or getattr(
-                    s, selector_attribute
-                ) not in selector_exclude
+                return (
+                    not hasattr(s, selector_attribute)
+                    or getattr(s, selector_attribute) not in selector_exclude
+                )
+
             return list(filter(keep, prj.samples))
         else:
             return list(prj.samples)
@@ -770,9 +773,9 @@ def fetch_samples(
     # Ensure that we're working with sets.
     def make_set(items):
         try:
-            #Check if user input single integer value for inclusion/exclusion criteria
+            # Check if user input single integer value for inclusion/exclusion criteria
             if len(items) == 1:
-                items = list(map(int, items)) #list(int(items[0]))
+                items = list(map(int, items))  # list(int(items[0]))
         except:
             if isinstance(items, str):
                 items = [items]

--- a/looper/project.py
+++ b/looper/project.py
@@ -129,15 +129,6 @@ class Project(peppyProject):
         return self._extra_cli_or_cfg(PIFACE_KEY_SELECTOR) or PIPELINE_INTERFACES_KEY
 
     @property
-    def toggle_key(self):
-        """
-        Name of the toggle attribute for this project
-
-        :return str: name of the toggle attribute
-        """
-        return self._extra_cli_or_cfg(TOGGLE_KEY_SELECTOR) or SAMPLE_TOGGLE_ATTR
-
-    @property
     def selected_compute_package(self):
         """
         Compute package name specified in object constructor
@@ -732,7 +723,7 @@ def fetch_samples(
         Python2;
         also possible if name of attribute for selection isn't a string
     """
-    if selector_attribute is None or (not selector_include and not selector_exclude):
+    if not selector_include and not selector_exclude:
         # Default case where user does not use selector_include or selector exclude.
         # Assume that user wants to exclude samples if toggle = 0.
         if any([hasattr(s, "toggle") for s in prj.samples]):


### PR DESCRIPTION
Removed --toggle-key functionality. Moved checks for toggled sample to fetch_samples. Allows for user to input single integer value for --sel-incl or --sel-excl. Closes https://github.com/pepkit/looper/issues/263 and closes https://github.com/pepkit/looper/issues/173