### PR TITLE
Simple check to see if provided pipelines are callable during write_script

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,16 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - ability to use PEPs from PEPhub without downloading project [#341](https://github.com/pepkit/looper/issues/341)
 - ability to specify pipeline interfaces inside looper config instead/
+- divvy re-integrated in looper
+- divvy inspect -p package
+- Looper will now check that the command path provided in the pipeline interface is callable before submitting.
+
 
 ### Changed
 - initialization of generic pipeline interface available using subcommand `init-piface`
+- `looper report` will now use pipestat to generate browsable HTML reports if pipestat is configured.
+- looper now works with pipestat v0.4.0.
 
-
-## [1.5.0] -- 2023-05-12
-
-### Added
-- divvy re-integrated in looper
-- divvy inspect -p package
 
 ## [1.4.0] -- 2023-04-24
 

--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -774,11 +774,14 @@ class SubmissionConductor(object):
 
     def check_executable_path(self, pl_iface):
         """Determines if supplied pipelines are callable.
-        Raises error and exits Looper if not callable"""
-        pl_iface = pl_iface
+        Raises error and exits Looper if not callable
+        :param dict pl_iface: pipeline interface that stores paths to executables
+        :return bool: True if path is callable.
+        """
         pipeline_commands = []
         if "path" in pl_iface.keys():
             pipeline_commands.append(pl_iface["path"])
+
         if (
             "var_templates" in pl_iface.keys()
             and "pipeline" in pl_iface["var_templates"].keys()

--- a/looper/conductor.py
+++ b/looper/conductor.py
@@ -17,14 +17,15 @@ from jinja2.exceptions import UndefinedError
 from peppy.const import CONFIG_KEY, SAMPLE_NAME_ATTR, SAMPLE_YAML_EXT
 from peppy.exceptions import RemoteYAMLError
 from pipestat import PipestatError
-from ubiquerg import expandpath
+from ubiquerg import expandpath, is_command_callable
 from yaml import dump
 from yacman import YAMLConfigManager
 
 from .const import *
-from .exceptions import JobSubmissionException
+from .exceptions import JobSubmissionException, SampleFailedException
 from .processed_project import populate_sample_paths
 from .utils import fetch_sample_flags, jinja_render_template_strictly
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -719,6 +720,10 @@ class SubmissionConductor(object):
                 namespaces=namespaces
             )
             _LOGGER.debug(f"namespace pipelines: { pl_iface }")
+
+            # check here to ensure command is executable
+            self.check_executable_path(pl_iface)
+
             namespaces["pipeline"]["var_templates"] = pl_iface[VAR_TEMPL_KEY]
             # pre_submit hook namespace updates
             namespaces = _exec_pre_submit(pl_iface, namespaces)
@@ -766,6 +771,31 @@ class SubmissionConductor(object):
     def _reset_curr_skips(self):
         self._curr_skip_pool = []
         self._curr_skip_size = 0
+
+    def check_executable_path(self, pl_iface):
+        """Determines if supplied pipelines are callable.
+        Raises error and exits Looper if not callable"""
+        pl_iface = pl_iface
+        pipeline_commands = []
+        if "path" in pl_iface.keys():
+            pipeline_commands.append(pl_iface["path"])
+        if (
+            "var_templates" in pl_iface.keys()
+            and "pipeline" in pl_iface["var_templates"].keys()
+        ):
+            pipeline_commands.append(pl_iface["var_templates"]["pipeline"])
+        for command in pipeline_commands:
+            try:
+                result = is_command_callable(command)
+            except:
+                _LOGGER.error(f" {command} IS NOT EXECUTABLE. EXITING")
+                raise SampleFailedException
+            else:
+                if not result:
+                    _LOGGER.error(f" {command} IS NOT EXECUTABLE. EXITING...")
+                    raise SampleFailedException
+                else:
+                    return True
 
 
 def _use_sample(flag, skips):

--- a/looper/pipeline_interface.py
+++ b/looper/pipeline_interface.py
@@ -9,7 +9,7 @@ import jsonschema
 import pandas as pd
 from eido import read_schema
 from peppy import utils as peputil
-from ubiquerg import expandpath, is_url
+from ubiquerg import expandpath, is_url, is_command_callable
 from yacman import load_yaml, YAMLConfigManager
 
 from .const import *

--- a/looper/pipeline_interface.py
+++ b/looper/pipeline_interface.py
@@ -9,7 +9,7 @@ import jsonschema
 import pandas as pd
 from eido import read_schema
 from peppy import utils as peputil
-from ubiquerg import expandpath, is_url, is_command_callable
+from ubiquerg import expandpath, is_url
 from yacman import load_yaml, YAMLConfigManager
 
 from .const import *


### PR DESCRIPTION
Addresses #195.

We can infer from the user provided pipeline_interface a path to the pipeline executable via 
```
var_templates:
    pipeline:
```
 We can check to see if this command is actually callable using `ubiquerg.is_command_callable`. If not, raise exception. This will cause the remaining samples for the specific pipeline to not continue.

Other thoughts:
-This will also prevent any further pipeline interfaces from running which may be undesirable (we just want the pipeline with an error to quit). For example:
```
sample_modifiers:
  append:
    pipeline_interfaces: [../pipeline/pipeline_interface4.yaml, ../pipeline/pipeline_interface5.yaml]
    toggle: 1
```
If pipeline_interface4 works fine, but pipeline_interface5 is not callable, Looper will run neither (confirmed via manual testing).

-It would be preferable to check if the command is executable before looper reaches `write_script`, however, the nested commands are rendered at `write_script` and depend on namespaces that are also created within `write_script`.