### PR TITLE
Add remaining arguments to `run` command model

### DIFF
--- a/looper/cli_pydantic.py
+++ b/looper/cli_pydantic.py
@@ -110,7 +110,7 @@ def run_looper(args: TopLevelParser, parser: ArgumentParser):
             p = Project(
                 amendments=args.amend,
                 divcfg_path=divcfg,
-                runp=args.command == "runp",
+                runp=subcommand_name == "runp",
                 project_dict=PEPHubClient()._load_raw_pep(
                     registry_path=args.config_file
                 ),
@@ -128,7 +128,7 @@ def run_looper(args: TopLevelParser, parser: ArgumentParser):
                 cfg=args.config_file,
                 amendments=args.amend,
                 divcfg_path=divcfg,
-                runp=False,
+                runp=subcommand_name == "runp",
                 **{
                     attr: getattr(args, attr) for attr in CLI_PROJ_ATTRS if attr in args
                 },
@@ -146,11 +146,11 @@ def run_looper(args: TopLevelParser, parser: ArgumentParser):
 
     with ProjectContext(
         prj=p,
-        selector_attribute="toggle",
-        selector_include=None,
-        selector_exclude=None,
-        selector_flag=None,
-        exclusion_flag=None,
+        selector_attribute=args.sel_attr,
+        selector_include=args.sel_incl,
+        selector_exclude=args.sel_excl,
+        selector_flag=args.sel_flag,
+        exclusion_flag=args.exc_flag,
     ) as prj:
         if subcommand_name == "run":
             run = Runner(prj)

--- a/looper/command_models/arguments.py
+++ b/looper/command_models/arguments.py
@@ -152,6 +152,21 @@ class ArgumentEnum(enum.Enum):
     AMEND = Argument(
         name="amend", default=(List, []), description="List of amendments to activate"
     )
+    SEL_ATTR = Argument(
+        name="sel_attr",
+        default=(str, "toggle"),
+        description="Attribute for sample exclusion OR inclusion",
+    )
+    SEL_INCL = Argument(
+        name="sel_incl",
+        default=(str, ""),
+        description="Include only samples with these values",
+    )
+    SEL_EXCL = Argument(
+        name="sel_excl",
+        default=(str, ""),
+        description="Exclude samples with these values",
+    )
     SEL_FLAG = Argument(
         name="sel_flag", default=(str, ""), description="Sample selection flag"
     )

--- a/looper/command_models/commands.py
+++ b/looper/command_models/commands.py
@@ -89,6 +89,9 @@ class TopLevelParser(pydantic.BaseModel):
         ArgumentEnum.PROJECT_PIPELINE_INTERFACES.value.with_reduced_default()
     )
     amend: Optional[List[str]] = ArgumentEnum.AMEND.value.with_reduced_default()
+    sel_attr: Optional[str] = ArgumentEnum.SEL_ATTR.value.with_reduced_default()
+    sel_incl: Optional[str] = ArgumentEnum.SEL_INCL.value.with_reduced_default()
+    sel_excl: Optional[str] = ArgumentEnum.SEL_EXCL.value.with_reduced_default()
     sel_flag: Optional[str] = ArgumentEnum.SEL_FLAG.value.with_reduced_default()
     exc_flag: Optional[str] = ArgumentEnum.EXC_FLAG.value.with_reduced_default()
     # arguments for logging


### PR DESCRIPTION
While #441 is meant to just get the `hello_looper` example working, meaning just a `looper run` with the basic example config file given in the `hello_looper` repository, it lacks a couple arguments that make it fully compatible with general `looper run` uses, as pointed out by @donaldcampbelljr in https://github.com/pepkit/looper/pull/440#issuecomment-1910277389.

This PR aims to add all remaining arguments to the `run` command, and thus to provide full feature compatibility (for the `run` command) between the current `argparse`-based `looper` CLI and the `pydantic-argparse`-based one.

We encourage all `looper` users to check whether their `looper run` commands work as intended when using the `looper-pydantic-argparse` script as described in #441.

> [!NOTE]
There are still no tests for that in the test suite - it is not clear we are going to keep `pydantic-argparse` as a library to build a CLI from `pydantic` models, but these models are the foundation of the HTTP API being developed in #441.