### PR TITLE
Dev 474

### DIFF
--- a/looper/utils.py
+++ b/looper/utils.py
@@ -560,6 +560,9 @@ def read_looper_config_file(looper_config_path: str) -> dict:
 
     # Expand paths in case ENV variables are used
     for k, v in return_dict.items():
+        if k == SAMPLE_PL_ARG or k == PROJECT_PL_ARG:
+            # Pipeline interfaces are resolved at a later point. Do it there only to maintain consistency. #474
+            pass
         if isinstance(v, str):
             v = expandpath(v)
             # TODO this is messy because is_pephub_registry needs to fail on anything NOT a pephub registry path

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -148,6 +148,7 @@ def test_comprehensive_looper_pipestat(prep_temp_pep_pipestat):
         retrieved_result = psm.retrieve_one(record_identifier="frog_2")
 
 
+@pytest.mark.skipif(not is_connected(), reason="This test needs internet access.")
 def test_comprehensive_looper_pephub(prep_temp_pep_pephub):
     """Basic test to determine if Looper can run a PEP from PEPHub"""
 


### PR DESCRIPTION
Simple fix for #474. During resolution of  config file, skip the pipeline interfaces portion, because looper has code for this explicit purpose and doing it in two different places is causing consistency issues.